### PR TITLE
Latest memory violaton protections cause segmentation faults.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ farhorizons.cfg
 /.cproject
 /.project
 /.settings/
+/.pydevproject

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ farhorizons.cfg
 *.nav
 *.snm
 *.vrb
+/.cproject
+/.project
+/.settings/

--- a/src/mk.addsp
+++ b/src/mk.addsp
@@ -3,7 +3,7 @@ ADD_OBJS = AddSpecies.o utils.o get_gal.o get_star.o get_plan.o scan.o gam_abo.o
 
 
 AddSpecies: $(ADD_OBJS)
-	cc $(ADD_OBJS) -o ../bin/AddSpecies
+	cc $(ADD_OBJS) -no-pie -o ../bin/AddSpecies
 
 AddSpecies.o: AddSpecies.c fh.h
 	cc -no-pie -c AddSpecies.c

--- a/src/mk.addsp
+++ b/src/mk.addsp
@@ -6,25 +6,25 @@ AddSpecies: $(ADD_OBJS)
 	cc $(ADD_OBJS) -o ../bin/AddSpecies
 
 AddSpecies.o: AddSpecies.c fh.h
-	cc -c AddSpecies.c
+	cc -no-pie -c AddSpecies.c
 
 utils.o: utils.c fh.h
-	cc -c utils.c
+	cc -no-pie -c utils.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c
 
 get_plan.o: get_plan.c fh.h
-	cc -c get_plan.c
+	cc -no-pie -c get_plan.c
 
 sav_star.o: sav_star.c fh.h
-	cc -c sav_star.c
+	cc -no-pie -c sav_star.c
 
 scan.o: scan.c fh.h
-	cc -c scan.c
+	cc -no-pie -c scan.c
 
 gam_abo.o: gam_abo.c fh.h
-	cc -c gam_abo.c
+	cc -no-pie -c gam_abo.c

--- a/src/mk.addsp.auto
+++ b/src/mk.addsp.auto
@@ -6,25 +6,25 @@ AddSpeciesAuto: $(ADD_OBJS)
 	cc $(ADD_OBJS) -o ../bin/AddSpeciesAuto
 
 AddSpeciesAuto.o: AddSpeciesAuto.c fh.h
-	cc -c AddSpeciesAuto.c
+	cc -no-pie -c AddSpeciesAuto.c
 
 utils.o: utils.c fh.h
-	cc -c utils.c
+	cc -no-pie -c utils.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c
 
 get_plan.o: get_plan.c fh.h
-	cc -c get_plan.c
+	cc -no-pie -c get_plan.c
 
 sav_star.o: sav_star.c fh.h
-	cc -c sav_star.c
+	cc -no-pie -c sav_star.c
 
 scan.o: scan.c fh.h
-	cc -c scan.c
+	cc -no-pie -c scan.c
 
 gam_abo.o: gam_abo.c fh.h
-	cc -c gam_abo.c
+	cc -no-pie -c gam_abo.c

--- a/src/mk.addsp.auto
+++ b/src/mk.addsp.auto
@@ -3,7 +3,7 @@ ADD_OBJS = AddSpeciesAuto.o utils.o get_gal.o get_star.o get_plan.o scan.o gam_a
 
 
 AddSpeciesAuto: $(ADD_OBJS)
-	cc $(ADD_OBJS) -o ../bin/AddSpeciesAuto
+	cc $(ADD_OBJS) -no-pie -o ../bin/AddSpeciesAuto
 
 AddSpeciesAuto.o: AddSpeciesAuto.c fh.h
 	cc -no-pie -c AddSpeciesAuto.c

--- a/src/mk.asc
+++ b/src/mk.asc
@@ -7,19 +7,19 @@ AsciiToBinary: $(ASCII_OBJS)
 	cc -o ../bin/AsciiToBinary $(ASCII_OBJS)
 
 AsciiToBinary.o: AsciiToBinary.c fh.h
-	cc -c AsciiToBinary.c
+	cc -no-pie -c AsciiToBinary.c
 
 utils.o: utils.c fh.h
-	cc -c utils.c
+	cc -no-pie -c utils.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c
 
 get_plan.o: get_plan.c fh.h
-	cc -c get_plan.c
+	cc -no-pie -c get_plan.c
 
 sav_star.o: sav_star.c fh.h
-	cc -c sav_star.c
+	cc -no-pie -c sav_star.c
 
 sav_plan.o: sav_plan.c fh.h
-	cc -c sav_plan.c
+	cc -no-pie -c sav_plan.c

--- a/src/mk.asc
+++ b/src/mk.asc
@@ -4,7 +4,7 @@ ASCII1 = AsciiToBinary.o get_star.o get_plan.o sav_star.o sav_plan.o utils.o
 ASCII_OBJS = $(ASCII1)
 
 AsciiToBinary: $(ASCII_OBJS)
-	cc -o ../bin/AsciiToBinary $(ASCII_OBJS)
+	cc -no-pie -o ../bin/AsciiToBinary $(ASCII_OBJS)
 
 AsciiToBinary.o: AsciiToBinary.c fh.h
 	cc -no-pie -c AsciiToBinary.c

--- a/src/mk.bin
+++ b/src/mk.bin
@@ -7,16 +7,16 @@ BinaryToAscii: $(BINARY_OBJS)
 	cc -o ../bin/BinaryToAscii $(BINARY_OBJS)
 
 BinaryToAscii.o: BinaryToAscii.c fh.h
-	cc -c BinaryToAscii.c
+	cc -no-pie -c BinaryToAscii.c
 
 utils.o: utils.c fh.h
-	cc -c utils.c
+	cc -no-pie -c utils.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c
 
 get_plan.o: get_plan.c fh.h
-	cc -c get_plan.c
+	cc -no-pie -c get_plan.c

--- a/src/mk.bin
+++ b/src/mk.bin
@@ -4,7 +4,7 @@ BINARY1 = BinaryToAscii.o get_gal.o get_star.o get_plan.o utils.o
 BINARY_OBJS = $(BINARY1)
 
 BinaryToAscii: $(BINARY_OBJS)
-	cc -o ../bin/BinaryToAscii $(BINARY_OBJS)
+	cc -no-pie -o ../bin/BinaryToAscii $(BINARY_OBJS)
 
 BinaryToAscii.o: BinaryToAscii.c fh.h
 	cc -no-pie -c BinaryToAscii.c

--- a/src/mk.combat
+++ b/src/mk.combat
@@ -7,7 +7,7 @@ COMBAT_OBJS = Combat.o $(COM1) $(COM2) $(COM3)
 CC = cc -g -no-pie
 
 Combat: $(COMBAT_OBJS)
-	$(CC) $(COMBAT_OBJS) -o ../bin/Combat
+	$(CC) $(COMBAT_OBJS) -no-pie -o ../bin/Combat
 	rm -f ../bin/Strike
 	ln -s ../bin/Combat ../bin/Strike
 

--- a/src/mk.combat
+++ b/src/mk.combat
@@ -4,7 +4,7 @@ COM2 = fight_par.o do_bat.o do_round.o do_bomb.o do_siege.o get_spnam.o with_che
 COM3 = regen_sh.o get_gal.o get_plan.o sav_plan.o get_transact.o sav_transact.o
 
 COMBAT_OBJS = Combat.o $(COM1) $(COM2) $(COM3)
-CC = cc -g -fno-stack-protector
+CC = cc -g -no-pie
 
 Combat: $(COMBAT_OBJS)
 	$(CC) $(COMBAT_OBJS) -o ../bin/Combat

--- a/src/mk.combat
+++ b/src/mk.combat
@@ -4,7 +4,7 @@ COM2 = fight_par.o do_bat.o do_round.o do_bomb.o do_siege.o get_spnam.o with_che
 COM3 = regen_sh.o get_gal.o get_plan.o sav_plan.o get_transact.o sav_transact.o
 
 COMBAT_OBJS = Combat.o $(COM1) $(COM2) $(COM3)
-CC = cc -g
+CC = cc -g -fno-stack-protector
 
 Combat: $(COMBAT_OBJS)
 	$(CC) $(COMBAT_OBJS) -o ../bin/Combat

--- a/src/mk.edit
+++ b/src/mk.edit
@@ -3,7 +3,7 @@ EDIT_OBJS = Edit.o utils.o get_gal.o get_star.o get_plan.o do_locs.o sav_plan.o 
 
 
 Edit: $(EDIT_OBJS)
-	cc $(EDIT_OBJS) -o ../bin/Edit
+	cc $(EDIT_OBJS) -no-pie -o ../bin/Edit
 
 Edit.o: Edit.c fh.h
 	cc -no-pie -c Edit.c

--- a/src/mk.edit
+++ b/src/mk.edit
@@ -6,25 +6,25 @@ Edit: $(EDIT_OBJS)
 	cc $(EDIT_OBJS) -o ../bin/Edit
 
 Edit.o: Edit.c fh.h
-	cc -c Edit.c
+	cc -no-pie -c Edit.c
 
 utils.o: utils.c fh.h
-	cc -c utils.c
+	cc -no-pie -c utils.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c
 
 get_plan.o: get_plan.c fh.h
-	cc -c get_plan.c
+	cc -no-pie -c get_plan.c
 
 sav_star.o: sav_star.c fh.h
-	cc -c sav_star.c
+	cc -no-pie -c sav_star.c
 
 sav_plan.o: sav_plan.c fh.h
-	cc -c sav_plan.c
+	cc -no-pie -c sav_plan.c
 
 gen_plan.o: gen_plan.c fh.h
-	cc -c gen_plan.c
+	cc -no-pie -c gen_plan.c

--- a/src/mk.finish
+++ b/src/mk.finish
@@ -8,25 +8,25 @@ Finish: $(FIN_OBJS)
 	cc $(FIN_OBJS) -o ../bin/Finish
 
 Finish.o: Finish.c fh.h
-	cc -c Finish.c
+	cc -no-pie -c Finish.c
 
 utils.o: utils.c fh.h
-	cc -c utils.c
+	cc -no-pie -c utils.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 get_plan.o: get_plan.c fh.h
-	cc -c get_plan.c
+	cc -no-pie -c get_plan.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c
 
 sav_plan.o: sav_plan.c fh.h
-	cc -c sav_plan.c
+	cc -no-pie -c sav_plan.c
 
 get_transact.o: get_transact.c fh.h
-	cc -c get_transact.c
+	cc -no-pie -c get_transact.c
 
 do_locs.o: do_locs.c fh.h
-	cc -c do_locs.c
+	cc -no-pie -c do_locs.c

--- a/src/mk.finish
+++ b/src/mk.finish
@@ -5,7 +5,7 @@ FIN2 = get_gal.o get_star.o get_plan.o sav_plan.o do_locs.o
 FIN_OBJS = Finish.o $(FIN1) $(FIN2)
 
 Finish: $(FIN_OBJS)
-	cc $(FIN_OBJS) -o ../bin/Finish
+	cc $(FIN_OBJS) -no-pie -o ../bin/Finish
 
 Finish.o: Finish.c fh.h
 	cc -no-pie -c Finish.c

--- a/src/mk.home
+++ b/src/mk.home
@@ -3,7 +3,7 @@ HOM_OBJS = HomeSystem.o utils.o get_gal.o get_star.o sav_star.o get_plan.o sav_p
 
 
 HomeSystem: $(HOM_OBJS)
-	cc $(HOM_OBJS) -o ../bin/HomeSystem
+	cc $(HOM_OBJS) -no-pie -o ../bin/HomeSystem
 
 HomeSystem.o: HomeSystem.c fh.h
 	cc -no-pie -c HomeSystem.c

--- a/src/mk.home
+++ b/src/mk.home
@@ -6,26 +6,26 @@ HomeSystem: $(HOM_OBJS)
 	cc $(HOM_OBJS) -o ../bin/HomeSystem
 
 HomeSystem.o: HomeSystem.c fh.h
-	cc -c HomeSystem.c
+	cc -no-pie -c HomeSystem.c
 
 utils.o: utils.c fh.h
-	cc -c utils.c
+	cc -no-pie -c utils.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c
 
 get_plan.o: get_plan.c fh.h
-	cc -c get_plan.c
+	cc -no-pie -c get_plan.c
 
 sav_plan.o: sav_plan.c fh.h
-	cc -c sav_plan.c
+	cc -no-pie -c sav_plan.c
 
 sav_star.o: sav_star.c fh.h
-	cc -c sav_star.c
+	cc -no-pie -c sav_star.c
 
 gam_abo.o: gam_abo.c fh.h
-	cc -c gam_abo.c
+	cc -no-pie -c gam_abo.c
 

--- a/src/mk.home.auto
+++ b/src/mk.home.auto
@@ -6,26 +6,26 @@ HomeSystemAuto: $(HOM_OBJS)
 	cc $(HOM_OBJS) -o ../bin/HomeSystemAuto
 
 HomeSystemAuto.o: HomeSystemAuto.c fh.h
-	cc -c HomeSystemAuto.c
+	cc -no-pie -c HomeSystemAuto.c
 
 utils.o: utils.c fh.h
-	cc -c utils.c
+	cc -no-pie -c utils.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c
 
 get_plan.o: get_plan.c fh.h
-	cc -c get_plan.c
+	cc -no-pie -c get_plan.c
 
 sav_plan.o: sav_plan.c fh.h
-	cc -c sav_plan.c
+	cc -no-pie -c sav_plan.c
 
 sav_star.o: sav_star.c fh.h
-	cc -c sav_star.c
+	cc -no-pie -c sav_star.c
 
 gam_abo.o: gam_abo.c fh.h
-	cc -c gam_abo.c
+	cc -no-pie -c gam_abo.c
 

--- a/src/mk.home.auto
+++ b/src/mk.home.auto
@@ -3,7 +3,7 @@ HOM_OBJS = HomeSystemAuto.o utils.o get_gal.o get_star.o sav_star.o get_plan.o s
 
 
 HomeSystemAuto: $(HOM_OBJS)
-	cc $(HOM_OBJS) -o ../bin/HomeSystemAuto
+	cc $(HOM_OBJS) -no-pie -o ../bin/HomeSystemAuto
 
 HomeSystemAuto.o: HomeSystemAuto.c fh.h
 	cc -no-pie -c HomeSystemAuto.c

--- a/src/mk.jump
+++ b/src/mk.jump
@@ -7,7 +7,7 @@ JUMP_OBJS = Jump.o $(JUMP1) $(JUMP2) $(JUMP3)
 CC = cc -g -no-pie
 
 Jump: $(JUMP_OBJS)
-	$(CC) $(JUMP_OBJS) -o ../bin/Jump
+	$(CC) $(JUMP_OBJS) -no-pie -o ../bin/Jump
 
 Jump.o: Jump.c fh.h
 	$(CC) -c Jump.c

--- a/src/mk.jump
+++ b/src/mk.jump
@@ -4,7 +4,7 @@ JUMP2 = get_gal.o get_star.o get_plan.o sav_transact.o sav_star.o sav_plan.o
 JUMP3 = get_loc.o get_ship.o gam_abo.o dis_ship.o do_worm.o
 
 JUMP_OBJS = Jump.o $(JUMP1) $(JUMP2) $(JUMP3)
-CC = cc -g
+CC = cc -g -fno-stack-protector
 
 Jump: $(JUMP_OBJS)
 	$(CC) $(JUMP_OBJS) -o ../bin/Jump

--- a/src/mk.jump
+++ b/src/mk.jump
@@ -4,7 +4,7 @@ JUMP2 = get_gal.o get_star.o get_plan.o sav_transact.o sav_star.o sav_plan.o
 JUMP3 = get_loc.o get_ship.o gam_abo.o dis_ship.o do_worm.o
 
 JUMP_OBJS = Jump.o $(JUMP1) $(JUMP2) $(JUMP3)
-CC = cc -g -fno-stack-protector
+CC = cc -g -no-pie
 
 Jump: $(JUMP_OBJS)
 	$(CC) $(JUMP_OBJS) -o ../bin/Jump

--- a/src/mk.listgal
+++ b/src/mk.listgal
@@ -3,7 +3,7 @@ LIST_OBJS = ListGalaxy.o utils.o get_gal.o get_star.o get_plan.o
 
 
 ListGalaxy: $(LIST_OBJS)
-	cc $(LIST_OBJS) -o ../bin/ListGalaxy
+	cc $(LIST_OBJS) -no-pie -o ../bin/ListGalaxy
 
 ListGalaxy.o: ListGalaxy.c fh.h
 	cc -no-pie -c ListGalaxy.c

--- a/src/mk.listgal
+++ b/src/mk.listgal
@@ -6,16 +6,16 @@ ListGalaxy: $(LIST_OBJS)
 	cc $(LIST_OBJS) -o ../bin/ListGalaxy
 
 ListGalaxy.o: ListGalaxy.c fh.h
-	cc -c ListGalaxy.c
+	cc -no-pie -c ListGalaxy.c
 
 utils.o: utils.c fh.h
-	cc -c utils.c
+	cc -no-pie -c utils.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c
 
 get_plan.o: get_plan.c fh.h
-	cc -c get_plan.c
+	cc -no-pie -c get_plan.c

--- a/src/mk.loc
+++ b/src/mk.loc
@@ -5,7 +5,7 @@ LOC2 = get_gal.o get_plan.o get_star.o sav_plan.o
 LOC_OBJS = Locations.o $(LOC1) $(LOC2)
 
 Locations: $(LOC_OBJS)
-	cc $(LOC_OBJS) -o ../bin/Locations
+	cc $(LOC_OBJS) -no-pie -o ../bin/Locations
 
 Locations.o: Locations.c fh.h
 	cc -no-pie -c Locations.c

--- a/src/mk.loc
+++ b/src/mk.loc
@@ -8,22 +8,22 @@ Locations: $(LOC_OBJS)
 	cc $(LOC_OBJS) -o ../bin/Locations
 
 Locations.o: Locations.c fh.h
-	cc -c Locations.c
+	cc -no-pie -c Locations.c
 
 utils.o: utils.c fh.h
-	cc -c utils.c
+	cc -no-pie -c utils.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 get_plan.o: get_plan.c fh.h
-	cc -c get_plan.c
+	cc -no-pie -c get_plan.c
 
 get_star: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c
 
 sav_plan.o: sav_plan.c fh.h
-	cc -c sav_plan.c
+	cc -no-pie -c sav_plan.c
 
 do_locs.o: do_locs.c fh.h
-	cc -c do_locs.c
+	cc -no-pie -c do_locs.c

--- a/src/mk.mapgal
+++ b/src/mk.mapgal
@@ -6,10 +6,10 @@ MapGalaxy: $(MAP_OBJS)
 	cc $(MAP_OBJS) -o ../bin/MapGalaxy
 
 MapGalaxy.o: MapGalaxy.c fh.h
-	cc -c MapGalaxy.c
+	cc -no-pie -c MapGalaxy.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c

--- a/src/mk.mapgal
+++ b/src/mk.mapgal
@@ -3,7 +3,7 @@ MAP_OBJS = MapGalaxy.o get_gal.o get_star.o
 
 
 MapGalaxy: $(MAP_OBJS)
-	cc $(MAP_OBJS) -o ../bin/MapGalaxy
+	cc $(MAP_OBJS) -no-pie -o ../bin/MapGalaxy
 
 MapGalaxy.o: MapGalaxy.c fh.h
 	cc -no-pie -c MapGalaxy.c

--- a/src/mk.mapprint
+++ b/src/mk.mapprint
@@ -2,7 +2,7 @@
 MAP_OBJS = PrintMap.o
 
 MapGalaxy: $(MAP_OBJS)
-	cc -o ../bin/PrintMap $(MAP_OBJS) -lm
+	cc -no-pie -o ../bin/PrintMap $(MAP_OBJS) -lm
 
 PrintMap.o: PrintMap.c
 	cc -no-pie -c PrintMap.c

--- a/src/mk.mapprint
+++ b/src/mk.mapprint
@@ -5,4 +5,4 @@ MapGalaxy: $(MAP_OBJS)
 	cc -o ../bin/PrintMap $(MAP_OBJS) -lm
 
 PrintMap.o: PrintMap.c
-	cc -c PrintMap.c
+	cc -no-pie -c PrintMap.c

--- a/src/mk.mho
+++ b/src/mk.mho
@@ -6,10 +6,10 @@ MakeHomes: $(MHO_OBJS)
 	cc $(MHO_OBJS) -o ../bin/MakeHomes
 
 MakeHomes.o: MakeHomes.c fh.h
-	cc -c MakeHomes.c
+	cc -no-pie -c MakeHomes.c
 
 utils.o: utils.c fh.h
-	cc -c utils.c
+	cc -no-pie -c utils.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c

--- a/src/mk.mho
+++ b/src/mk.mho
@@ -3,7 +3,7 @@ MHO_OBJS = MakeHomes.o get_star.o utils.o
 
 
 MakeHomes: $(MHO_OBJS)
-	cc $(MHO_OBJS) -o ../bin/MakeHomes
+	cc $(MHO_OBJS) -no-pie -o ../bin/MakeHomes
 
 MakeHomes.o: MakeHomes.c fh.h
 	cc -no-pie -c MakeHomes.c

--- a/src/mk.near
+++ b/src/mk.near
@@ -6,19 +6,19 @@ Near: $(NEAR_OBJS)
 	cc $(NEAR_OBJS) -o ../bin/Near
 
 Near.o: Near.c fh.h
-	cc -c Near.c
+	cc -no-pie -c Near.c
 
 utils.o: utils.c fh.h
-	cc -c utils.c
+	cc -no-pie -c utils.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c
 
 get_plan.o: get_plan.c fh.h
-	cc -c get_plan.c
+	cc -no-pie -c get_plan.c
 
 scan.o: scan.c fh.h
-	cc -c scan.c
+	cc -no-pie -c scan.c

--- a/src/mk.near
+++ b/src/mk.near
@@ -3,7 +3,7 @@ NEAR_OBJS = Near.o utils.o get_gal.o get_star.o get_plan.o scan.o
 
 
 Near: $(NEAR_OBJS)
-	cc $(NEAR_OBJS) -o ../bin/Near
+	cc $(NEAR_OBJS) -no-pie -o ../bin/Near
 
 Near.o: Near.c fh.h
 	cc -no-pie -c Near.c

--- a/src/mk.newgal
+++ b/src/mk.newgal
@@ -3,7 +3,7 @@ NEW_OBJS = NewGalaxy.o get_star.o utils.o gen_plan.o
 
 
 NewGalaxy: $(NEW_OBJS)
-	cc $(NEW_OBJS) -o ../bin/NewGalaxy
+	cc $(NEW_OBJS) -no-pie -o ../bin/NewGalaxy
 
 NewGalaxy.o: NewGalaxy.c fh.h
 	cc -no-pie -c NewGalaxy.c

--- a/src/mk.newgal
+++ b/src/mk.newgal
@@ -6,13 +6,13 @@ NewGalaxy: $(NEW_OBJS)
 	cc $(NEW_OBJS) -o ../bin/NewGalaxy
 
 NewGalaxy.o: NewGalaxy.c fh.h
-	cc -c NewGalaxy.c
+	cc -no-pie -c NewGalaxy.c
 
 utils.o: utils.c fh.h
-	cc -c utils.c
+	cc -no-pie -c utils.c
 
 gen_plan.o: gen_plan.c fh.h
-	cc -c gen_plan.c
+	cc -no-pie -c gen_plan.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c

--- a/src/mk.no
+++ b/src/mk.no
@@ -6,7 +6,7 @@ NOO_OBJS = NoOrders.o $(NOO1) $(NOO2)
 
 
 NoOrders: $(NOO_OBJS)
-	cc $(NOO_OBJS) -o ../bin/NoOrders
+	cc $(NOO_OBJS) -no-pie -o ../bin/NoOrders
 
 NoOrders.o: NoOrders.c fh.h
 	cc -no-pie -c NoOrders.c

--- a/src/mk.no
+++ b/src/mk.no
@@ -9,19 +9,19 @@ NoOrders: $(NOO_OBJS)
 	cc $(NOO_OBJS) -o ../bin/NoOrders
 
 NoOrders.o: NoOrders.c fh.h
-	cc -c NoOrders.c
+	cc -no-pie -c NoOrders.c
 
 utils.o: utils.c fh.h
-	cc -c utils.c
+	cc -no-pie -c utils.c
 
 parse.o: parse.c fh.h
-	cc -c parse.c
+	cc -no-pie -c parse.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 get_plan.o: get_plan.c fh.h
-	cc -c get_plan.c
+	cc -no-pie -c get_plan.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c

--- a/src/mk.post
+++ b/src/mk.post
@@ -5,7 +5,7 @@ POST3 = get_transact.o get_spnam.o do_name.o do_orbit.o do_tech.o do_send.o do_d
 POST4 = sav_star.o get_loc.o get_ship.o gam_abo.o do_mes.o do_terr.o do_enemy.o do_tel.o do_teach.o get_transfer.o
 
 POST_OBJS = PostArrival.o $(POST1) $(POST2) $(POST3) $(POST4)
-CC = cc -g -fno-stack-protector
+CC = cc -g -no-pie
 
 PostArrival: $(POST_OBJS)
 	$(CC) $(POST_OBJS) -o ../bin/PostArrival

--- a/src/mk.post
+++ b/src/mk.post
@@ -8,7 +8,7 @@ POST_OBJS = PostArrival.o $(POST1) $(POST2) $(POST3) $(POST4)
 CC = cc -g -no-pie
 
 PostArrival: $(POST_OBJS)
-	$(CC) $(POST_OBJS) -o ../bin/PostArrival
+	$(CC) $(POST_OBJS) -no-pie -o ../bin/PostArrival
 
 PostArrival.o: PostArrival.c fh.h
 	$(CC) -c PostArrival.c

--- a/src/mk.post
+++ b/src/mk.post
@@ -5,7 +5,7 @@ POST3 = get_transact.o get_spnam.o do_name.o do_orbit.o do_tech.o do_send.o do_d
 POST4 = sav_star.o get_loc.o get_ship.o gam_abo.o do_mes.o do_terr.o do_enemy.o do_tel.o do_teach.o get_transfer.o
 
 POST_OBJS = PostArrival.o $(POST1) $(POST2) $(POST3) $(POST4)
-CC = cc -g
+CC = cc -g -fno-stack-protector
 
 PostArrival: $(POST_OBJS)
 	$(CC) $(POST_OBJS) -o ../bin/PostArrival

--- a/src/mk.pre
+++ b/src/mk.pre
@@ -10,103 +10,103 @@ PreDeparture: $(PRE_OBJS)
 	cc $(PRE_OBJS) -o ../bin/PreDeparture
 
 PreDeparture.o: PreDeparture.c fh.h
-	cc -c PreDeparture.c
+	cc -no-pie -c PreDeparture.c
 
 utils.o: utils.c fh.h
-	cc -c utils.c
+	cc -no-pie -c utils.c
 
 parse.o: parse.c fh.h
-	cc -c parse.c
+	cc -no-pie -c parse.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c
 
 get_plan.o: get_plan.c fh.h
-	cc -c get_plan.c
+	cc -no-pie -c get_plan.c
 
 get_transact.o: get_transact.c fh.h
-	cc -c get_transact.c
+	cc -no-pie -c get_transact.c
 
 sav_transact.o: sav_transact.c fh.h
-	cc -c sav_transact.c
+	cc -no-pie -c sav_transact.c
 
 get_loc.o: get_loc.c fh.h
-	cc -c get_loc.c
+	cc -no-pie -c get_loc.c
 
 get_spnam.o: get_spnam.c fh.h
-	cc -c get_spnam.c
+	cc -no-pie -c get_spnam.c
 
 get_ship.o: get_ship.c fh.h
-	cc -c get_ship.c
+	cc -no-pie -c get_ship.c
 
 do_tran.o: do_tran.c fh.h
-	cc -c do_tran.c
+	cc -no-pie -c do_tran.c
 
 do_send.o: do_send.c fh.h
-	cc -c do_send.c
+	cc -no-pie -c do_send.c
 
 do_scan.o: do_scan.c fh.h
-	cc -c do_scan.c
+	cc -no-pie -c do_scan.c
 
 scan.o: scan.c fh.h
-	cc -c scan.c
+	cc -no-pie -c scan.c
 
 do_inst.o: do_inst.c fh.h
-	cc -c do_inst.c
+	cc -no-pie -c do_inst.c
 
 do_ally.o: do_ally.c fh.h
-	cc -c do_ally.c
+	cc -no-pie -c do_ally.c
 
 do_enemy.o: do_enemy.c fh.h
-	cc -c do_enemy.c
+	cc -no-pie -c do_enemy.c
 
 do_neutral.o: do_neutral.c fh.h
-	cc -c do_neutral.c
+	cc -no-pie -c do_neutral.c
 
 do_name.o: do_name.c fh.h
-	cc -c do_name.c
+	cc -no-pie -c do_name.c
 
 do_deep.o: do_deep.c fh.h
-	cc -c do_deep.c
+	cc -no-pie -c do_deep.c
 
 do_land.o: do_land.c fh.h
-	cc -c do_land.c
+	cc -no-pie -c do_land.c
 
 do_orbit.o: do_orbit.c fh.h
-	cc -c do_orbit.c
+	cc -no-pie -c do_orbit.c
 
 do_mes.o: do_mes.c fh.h
-	cc -c do_mes.c
+	cc -no-pie -c do_mes.c
 
 do_rep.o: do_rep.c fh.h
-	cc -c do_rep.c
+	cc -no-pie -c do_rep.c
 
 do_unl.o: do_unl.c fh.h
-	cc -c do_unl.c
+	cc -no-pie -c do_unl.c
 
 do_des.o: do_des.c fh.h
-	cc -c do_des.c
+	cc -no-pie -c do_des.c
 
 do_base.o: do_base.c fh.h
-	cc -c do_base.c
+	cc -no-pie -c do_base.c
 
 do_disband.o: do_disband.c fh.h
-	cc -c do_disband.c
+	cc -no-pie -c do_disband.c
 
 dis_ship.o: dis_ship.c fh.h
-	cc -c dis_ship.c
+	cc -no-pie -c dis_ship.c
 
 gam_abo.o: gam_abo.c
-	cc -c gam_abo.c
+	cc -no-pie -c gam_abo.c
 
 get_transfer.o: get_transfer.c fh.h
-	cc -c get_transfer.c
+	cc -no-pie -c get_transfer.c
 
 sav_star.o: sav_star.c fh.h
-	cc -c sav_star.c
+	cc -no-pie -c sav_star.c
 
 sav_plan.o: sav_plan.c fh.h
-	cc -c sav_plan.c
+	cc -no-pie -c sav_plan.c

--- a/src/mk.pre
+++ b/src/mk.pre
@@ -7,7 +7,7 @@ PRE4 = sav_star.o sav_plan.o get_loc.o get_ship.o gam_abo.o do_name.o get_spnam.
 PRE_OBJS = PreDeparture.o $(PRE1) $(PRE2) $(PRE3) $(PRE4)
 
 PreDeparture: $(PRE_OBJS)
-	cc $(PRE_OBJS) -o ../bin/PreDeparture
+	cc $(PRE_OBJS) -no-pie -o ../bin/PreDeparture
 
 PreDeparture.o: PreDeparture.c fh.h
 	cc -no-pie -c PreDeparture.c

--- a/src/mk.pro
+++ b/src/mk.pro
@@ -7,7 +7,7 @@ PRO4 = get_loc.o do_amb.o get_transact.o sav_transact.o do_int.o get_star.o
 PRO_OBJS = Production.o $(PRO1) $(PRO2) $(PRO3) $(PRO4)
 
 Production: $(PRO_OBJS)
-	cc $(PRO_OBJS) -o ../bin/Production
+	cc $(PRO_OBJS) -no-pie -o ../bin/Production
 
 Production.o: Production.c fh.h
 	cc -no-pie -c Production.c

--- a/src/mk.pro
+++ b/src/mk.pro
@@ -10,88 +10,88 @@ Production: $(PRO_OBJS)
 	cc $(PRO_OBJS) -o ../bin/Production
 
 Production.o: Production.c fh.h
-	cc -c Production.c
+	cc -no-pie -c Production.c
 
 utils.o: utils.c fh.h
-	cc -c utils.c
+	cc -no-pie -c utils.c
 
 parse.o: parse.c fh.h
-	cc -c parse.c
+	cc -no-pie -c parse.c
 
 money.o: money.c fh.h
-	cc -c money.c
+	cc -no-pie -c money.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c
 
 get_plan.o: get_plan.c fh.h
-	cc -c get_plan.c
+	cc -no-pie -c get_plan.c
 
 get_ship.o: get_ship.c fh.h
-	cc -c get_ship.c
+	cc -no-pie -c get_ship.c
 
 get_spnam.o: get_spnam.c fh.h
-	cc -c get_spnam.c
+	cc -no-pie -c get_spnam.c
 
 sav_plan.o: sav_plan.c fh.h
-	cc -c sav_plan.c
+	cc -no-pie -c sav_plan.c
 
 do_prod.o: do_prod.c fh.h
-	cc -c do_prod.c
+	cc -no-pie -c do_prod.c
 
 do_build.o: do_build.c fh.h
-	cc -c do_build.c
+	cc -no-pie -c do_build.c
 
 do_recy.o: do_recy.c fh.h
-	cc -c do_recy.c
+	cc -no-pie -c do_recy.c
 
 do_res.o: do_res.c fh.h
-	cc -c do_res.c
+	cc -no-pie -c do_res.c
 
 do_est.o: do_est.c fh.h
-	cc -c do_est.c
+	cc -no-pie -c do_est.c
 
 do_upg.o: do_upg.c fh.h
-	cc -c do_upg.c
+	cc -no-pie -c do_upg.c
 
 do_amb.o: do_amb.c fh.h
-	cc -c do_amb.c
+	cc -no-pie -c do_amb.c
 
 do_int.o: do_int.c fh.h
-	cc -c do_int.c
+	cc -no-pie -c do_int.c
 
 do_hide.o: do_hide.c fh.h
-	cc -c do_hide.c
+	cc -no-pie -c do_hide.c
 
 do_ally.o: do_ally.c fh.h
-	cc -c do_ally.c
+	cc -no-pie -c do_ally.c
 
 do_enemy.o: do_enemy.c fh.h
-	cc -c do_enemy.c
+	cc -no-pie -c do_enemy.c
 
 do_neutral.o: do_neutral.c fh.h
-	cc -c do_neutral.c
+	cc -no-pie -c do_neutral.c
 
 do_shipyard.o: do_shipyard.c fh.h
-	cc -c do_shipyard.c
+	cc -no-pie -c do_shipyard.c
 
 do_dev.o: do_dev.c fh.h
-	cc -c do_dev.c
+	cc -no-pie -c do_dev.c
 
 gam_abo.o: gam_abo.c
-	cc -c gam_abo.c
+	cc -no-pie -c gam_abo.c
 
 get_transact.o: get_transact.c fh.h
-	cc -c get_transact.c
+	cc -no-pie -c get_transact.c
 
 get_loc.o: get_loc.c fh.h
-	cc -c get_loc.c
+	cc -no-pie -c get_loc.c
 
 sav_transact.o: sav_transact.c fh.h
-	cc -c sav_transact.c
+	cc -no-pie -c sav_transact.c
 
 get_transfer.o: get_transfer.c fh.h
-	cc -c get_transfer.c
+	cc -no-pie -c get_transfer.c

--- a/src/mk.report
+++ b/src/mk.report
@@ -1,6 +1,6 @@
 
 REP_OBJS = Report.o get_gal.o get_star.o get_plan.o utils.o
-CC = cc -g -fno-stack-protector
+CC = cc -g -no-pie
 
 Report: $(REP_OBJS)
 	$(CC) $(REP_OBJS) -o ../bin/Report

--- a/src/mk.report
+++ b/src/mk.report
@@ -1,6 +1,6 @@
 
 REP_OBJS = Report.o get_gal.o get_star.o get_plan.o utils.o
-CC = cc -g
+CC = cc -g -fno-stack-protector
 
 Report: $(REP_OBJS)
 	$(CC) $(REP_OBJS) -o ../bin/Report

--- a/src/mk.report
+++ b/src/mk.report
@@ -3,7 +3,7 @@ REP_OBJS = Report.o get_gal.o get_star.o get_plan.o utils.o
 CC = cc -g -no-pie
 
 Report: $(REP_OBJS)
-	$(CC) $(REP_OBJS) -o ../bin/Report
+	$(CC) $(REP_OBJS) -no-pie -o ../bin/Report
 
 Report.o: Report.c fh.h
 	$(CC) -c Report.c

--- a/src/mk.scan
+++ b/src/mk.scan
@@ -9,22 +9,22 @@ ScanSpXYZ: $(SCAN_OBJS)
 	cc $(SCAN_OBJS) -o ../bin/ScanSpXYZ
 
 ScanSpXYZ.o: ScanSpXYZ.c fh.h
-	cc -c ScanSpXYZ.c
+	cc -no-pie -c ScanSpXYZ.c
 
 get_spec.o: get_spec.c fh.h
-	cc -c get_spec.c
+	cc -no-pie -c get_spec.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c
 
 get_plan.o: get_plan.c fh.h
-	cc -c get_plan.c
+	cc -no-pie -c get_plan.c
 
 scan.o: scan.c fh.h
-	cc -c scan.c
+	cc -no-pie -c scan.c
 
 utils.o: utils.c fh.h
-	cc -c utils.c
+	cc -no-pie -c utils.c

--- a/src/mk.scan
+++ b/src/mk.scan
@@ -6,7 +6,7 @@ SCAN_OBJS = ScanSpXYZ.o $(SCAN1) $(SCAN2)
 
 
 ScanSpXYZ: $(SCAN_OBJS)
-	cc $(SCAN_OBJS) -o ../bin/ScanSpXYZ
+	cc $(SCAN_OBJS) -no-pie -o ../bin/ScanSpXYZ
 
 ScanSpXYZ.o: ScanSpXYZ.c fh.h
 	cc -no-pie -c ScanSpXYZ.c

--- a/src/mk.set
+++ b/src/mk.set
@@ -6,19 +6,19 @@ Set: $(SET_OBJS)
 	cc -o ../bin/Set $(SET_OBJS)
 
 Set.o: Set.c fh.h
-	cc -c Set.c
+	cc -no-pie -c Set.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c
 
 get_plan.o: get_plan.c fh.h
-	cc -c get_plan.c
+	cc -no-pie -c get_plan.c
 
 sav_star.o: sav_star.c fh.h
-	cc -c sav_star.c
+	cc -no-pie -c sav_star.c
 
 sav_plan.o: sav_plan.c fh.h
-	cc -c sav_plan.c
+	cc -no-pie -c sav_plan.c

--- a/src/mk.set
+++ b/src/mk.set
@@ -3,7 +3,7 @@ SET_OBJS = Set.o get_gal.o get_star.o get_plan.o sav_star.o sav_plan.o
 
 
 Set: $(SET_OBJS)
-	cc -o ../bin/Set $(SET_OBJS)
+	cc -no-pie -o ../bin/Set $(SET_OBJS)
 
 Set.o: Set.c fh.h
 	cc -no-pie -c Set.c

--- a/src/mk.setup
+++ b/src/mk.setup
@@ -3,7 +3,7 @@ SETUP_OBJS = Setup.o parse.o get_gal.o gam_abo.o
 
 
 Setup: $(SETUP_OBJS)
-	cc $(SETUP_OBJS) -o FH:bin/Setup
+	cc $(SETUP_OBJS) -no-pie -o ..:bin/Setup
 
 Setup.o: Setup.c fh.h
 	cc -no-pie -c Setup.c

--- a/src/mk.setup
+++ b/src/mk.setup
@@ -6,13 +6,13 @@ Setup: $(SETUP_OBJS)
 	cc $(SETUP_OBJS) -o FH:bin/Setup
 
 Setup.o: Setup.c fh.h
-	cc -c Setup.c
+	cc -no-pie -c Setup.c
 
 parse.o: parse.c fh.h
-	cc -c parse.c
+	cc -no-pie -c parse.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 gam_abo.o: gam_abo.c
-	cc -c gam_abo.c
+	cc -no-pie -c gam_abo.c

--- a/src/mk.showgal
+++ b/src/mk.showgal
@@ -6,13 +6,13 @@ ShowGalaxy: $(SHOW_OBJS)
 	cc $(SHOW_OBJS) -o ../bin/ShowGalaxy
 
 ShowGalaxy.o: ShowGalaxy.c fh.h
-	cc -c ShowGalaxy.c
+	cc -no-pie -c ShowGalaxy.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 get_star.o: get_star.c fh.h
-	cc -c get_star.c
+	cc -no-pie -c get_star.c
 
 get_plan.o: get_plan.c fh.h
-	cc -c get_plan.c
+	cc -no-pie -c get_plan.c

--- a/src/mk.showgal
+++ b/src/mk.showgal
@@ -3,7 +3,7 @@ SHOW_OBJS = ShowGalaxy.o get_gal.o get_star.o get_plan.o
 
 
 ShowGalaxy: $(SHOW_OBJS)
-	cc $(SHOW_OBJS) -o ../bin/ShowGalaxy
+	cc $(SHOW_OBJS) -no-pie -o ../bin/ShowGalaxy
 
 ShowGalaxy.o: ShowGalaxy.c fh.h
 	cc -no-pie -c ShowGalaxy.c

--- a/src/mk.stats
+++ b/src/mk.stats
@@ -2,7 +2,7 @@
 STAT_OBJS = Stats.o get_gal.o get_star.o get_plan.o utils.o combat_utils.o
 
 Stats: $(STAT_OBJS)
-	cc $(STAT_OBJS) -no-pie -o ../bin/Stats
+	cc $(STAT_OBJS) -no-pie -no-pie -o ../bin/Stats
 
 Stats.o: Stats.c fh.h
 	cc -no-pie -c Stats.c

--- a/src/mk.stats
+++ b/src/mk.stats
@@ -2,19 +2,19 @@
 STAT_OBJS = Stats.o get_gal.o get_star.o get_plan.o utils.o combat_utils.o
 
 Stats: $(STAT_OBJS)
-	cc $(STAT_OBJS) -o ../bin/Stats
+	cc $(STAT_OBJS) -no-pie -o ../bin/Stats
 
 Stats.o: Stats.c fh.h
-	cc -c Stats.c
+	cc -no-pie -c Stats.c
 
 utils.o: utils.c fh.h
-	cc -c utils.c
+	cc -no-pie -c utils.c
 
 combat_utils.o: combat_utils.c
-	cc -c combat_utils.c
+	cc -no-pie -c combat_utils.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c
 
 get_plan.o: get_plan.c fh.h
-	cc -c get_plan.c
+	cc -no-pie -c get_plan.c

--- a/src/mk.turn
+++ b/src/mk.turn
@@ -6,7 +6,7 @@ TurnNumber: $(TURN_OBJS)
 	cc $(TURN_OBJS) -o ../bin/TurnNumber
 
 TurnNumber.o: TurnNumber.c fh.h
-	cc -c TurnNumber.c
+	cc -no-pie -c TurnNumber.c
 
 get_gal.o: get_gal.c fh.h
-	cc -c get_gal.c
+	cc -no-pie -c get_gal.c

--- a/src/mk.turn
+++ b/src/mk.turn
@@ -3,7 +3,7 @@ TURN_OBJS = TurnNumber.o get_gal.o
 
 
 TurnNumber: $(TURN_OBJS)
-	cc $(TURN_OBJS) -o ../bin/TurnNumber
+	cc $(TURN_OBJS) -no-pie -o ../bin/TurnNumber
 
 TurnNumber.o: TurnNumber.c fh.h
 	cc -no-pie -c TurnNumber.c


### PR DESCRIPTION
Adding -no-pie as a compile time option permits the program to run. (so far).